### PR TITLE
Add codegen step to validate-cases workflow

### DIFF
--- a/.github/workflows/validate-cases.yml
+++ b/.github/workflows/validate-cases.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Codegen
+        run: pnpm codegen
+
       - name: Typecheck
         run: pnpm typecheck
 


### PR DESCRIPTION
## Summary
Added a codegen step to the validate-cases CI workflow to ensure generated code is up-to-date before type checking.

## Changes
- Added `pnpm codegen` step in the validate-cases workflow after dependency installation and before type checking
- This ensures that any code generation requirements are fulfilled before the typecheck step runs

## Details
The codegen step is positioned strategically in the workflow:
1. After `pnpm install --frozen-lockfile` (dependencies are ready)
2. Before `pnpm typecheck` (generated code is available for type checking)

This prevents type checking failures that could occur if generated code is missing or out-of-date.

https://claude.ai/code/session_01TSt6HCNgNnuVYGJffrv7ie