### PR TITLE
Add Envio RPC mode benchmark alongside HyperSync mode

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           INDEXERS="${{ inputs.indexers }}"
           if [ -z "$INDEXERS" ]; then
-            echo 'matrix=["envio","ponder","rindexer","subquery","sqd"]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=["envio","envio-rpc","ponder","rindexer","subquery","sqd"]' >> "$GITHUB_OUTPUT"
           else
             MATRIX=$(echo "$INDEXERS" | tr ' ' '\n' | jq -R . | jq -sc .)
             echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
@@ -149,7 +149,7 @@ jobs:
                 const content = fs.readFileSync(file, 'utf8');
                 outputs.push(content);
 
-                const match = content.match(/Summary — (\w+): ([\d,]+) blocks, ([\d,]+) events/);
+                const match = content.match(/Summary — (.+?): ([\d,]+) blocks, ([\d,]+) events/);
                 if (match) {
                   const name = match[1];
                   const blocks = parseInt(match[2].replace(/,/g, ''), 10);
@@ -206,7 +206,7 @@ jobs:
                 const content = fs.readFileSync(file, 'utf8');
                 outputs.push(content);
 
-                const match = content.match(/Summary — (\w+): ([\d,]+) blocks, ([\d,]+) events/);
+                const match = content.match(/Summary — (.+?): ([\d,]+) blocks, ([\d,]+) events/);
                 if (match) {
                   const name = match[1];
                   const blocks = parseInt(match[2].replace(/,/g, ''), 10);

--- a/cases/erc20-transfer-events/envio/.env.example
+++ b/cases/erc20-transfer-events/envio/.env.example
@@ -1,2 +1,8 @@
 # To create or update a token visit https://envio.dev/app/api-tokens
 ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
+
+# RPC URL used for fallback (HyperSync mode) or sync (RPC mode)
+ENVIO_RPC_URL="https://1.rpc.hypersync.xyz/<YOUR-API-TOKEN>"
+
+# Set to "sync" to force RPC for historical sync, or "fallback" (default) to use HyperSync
+ENVIO_RPC_FOR="fallback"

--- a/cases/erc20-transfer-events/envio/config.yaml
+++ b/cases/erc20-transfer-events/envio/config.yaml
@@ -9,6 +9,9 @@ contracts:
 chains:
   - id: 1 # Ethereum Mainnet
     start_block: 18600000
+    rpc:
+      url: ${ENVIO_RPC_URL}
+      for: ${ENVIO_RPC_FOR:-fallback}
     contracts:
       - name: ERC20
         address: 0xae78736cd615f374d3085123a210448e74fc6393 # RocketTokenRETH

--- a/cases/erc20-transfer-events/run.ts
+++ b/cases/erc20-transfer-events/run.ts
@@ -278,8 +278,12 @@ async function benchmarkPonder(rpcUrl: string): Promise<BenchmarkResult> {
 const ENVIO_PG_PORT = 5433;
 const ENVIO_DB_URL = `postgresql://postgres:testing@localhost:${ENVIO_PG_PORT}/envio-dev`;
 
-async function benchmarkEnvio(rpcUrl: string): Promise<BenchmarkResult> {
-  console.log("\n--- Envio ---\n");
+async function benchmarkEnvioImpl(
+  rpcUrl: string,
+  mode: "hypersync" | "rpc"
+): Promise<BenchmarkResult> {
+  const label = mode === "rpc" ? "Envio - RPC" : "Envio";
+  console.log(`\n--- ${label} ---\n`);
 
   // Clean previous state
   console.log("Cleaning envio cache...");
@@ -297,6 +301,8 @@ async function benchmarkEnvio(rpcUrl: string): Promise<BenchmarkResult> {
     TUI_OFF: "true",
     ENVIO_HASURA: "false",
     ENVIO_PG_PORT: String(ENVIO_PG_PORT),
+    ENVIO_RPC_URL: rpcUrl,
+    ENVIO_RPC_FOR: mode === "rpc" ? "sync" : "fallback",
   };
   console.log(`\nStarting envio dev for ${DURATION_S}s...\n`);
   await exec("pnpm", ["envio", "codegen"], ENVIO_DIR, envioEnv);
@@ -324,10 +330,18 @@ async function benchmarkEnvio(rpcUrl: string): Promise<BenchmarkResult> {
   const totalBlocks = progressBlock > START_BLOCK ? progressBlock - START_BLOCK : 0;
 
   return {
-    name: "Envio",
+    name: label,
     totalEvents,
     totalBlocks,
   };
+}
+
+async function benchmarkEnvio(rpcUrl: string): Promise<BenchmarkResult> {
+  return benchmarkEnvioImpl(rpcUrl, "hypersync");
+}
+
+async function benchmarkEnvioRpc(rpcUrl: string): Promise<BenchmarkResult> {
+  return benchmarkEnvioImpl(rpcUrl, "rpc");
 }
 
 // ── Rindexer Benchmark ────────────────────────────────────────────────
@@ -694,6 +708,7 @@ async function benchmarkSqd(rpcUrl: string): Promise<BenchmarkResult> {
 const BENCHMARKS: Record<string, (rpcUrl: string) => Promise<BenchmarkResult>> =
   {
     envio: benchmarkEnvio,
+    "envio-rpc": benchmarkEnvioRpc,
     ponder: benchmarkPonder,
     rindexer: benchmarkRindexer,
     subquery: benchmarkSubQuery,


### PR DESCRIPTION
## Summary
This PR adds support for benchmarking Envio in RPC mode alongside the existing HyperSync mode. This allows for performance comparison between the two data fetching strategies.

## Key Changes
- **Refactored Envio benchmarking logic**: Extracted the core benchmarking implementation into `benchmarkEnvioImpl()` that accepts a `mode` parameter ("hypersync" or "rpc")
- **Added RPC mode support**: Created `benchmarkEnvioRpc()` wrapper function to run benchmarks using RPC for historical sync
- **Updated environment configuration**: Added `ENVIO_RPC_URL` and `ENVIO_RPC_FOR` environment variables to control RPC behavior
- **Extended benchmark matrix**: Added "envio-rpc" to the default benchmark matrix in GitHub Actions workflow
- **Updated regex patterns**: Modified summary parsing regex in CI workflow from `(\w+)` to `(.+?)` to handle multi-word indexer names like "Envio - RPC"
- **Updated documentation**: Added RPC configuration examples to `.env.example` and `config.yaml`

## Implementation Details
- The `benchmarkEnvioImpl()` function now dynamically sets the label based on mode ("Envio" for HyperSync, "Envio - RPC" for RPC mode)
- RPC configuration is passed via environment variables that are injected into the Envio dev process
- The `ENVIO_RPC_FOR` setting controls whether RPC is used as primary sync method or fallback
- Both benchmark variants are registered in the `BENCHMARKS` registry for execution

https://claude.ai/code/session_01RSbY3oS8v9iRdg9gieTjsT