### PR TITLE
Downgrade envio to pg-client-downgrade variant

### DIFF
--- a/cases/erc20-transfer-events/envio/package.json
+++ b/cases/erc20-transfer-events/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.0.16"
   },
   "dependencies": {
-    "envio": "3.0.0-alpha.18"
+    "envio": "3.0.0-alpha.18-main-pg-client-downgrade"
   },
   "optionalDependencies": {
     "generated": "./generated"

--- a/cases/erc20-transfer-events/envio/pnpm-lock.yaml
+++ b/cases/erc20-transfer-events/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.0.0-alpha.18
-        version: 3.0.0-alpha.18(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        specifier: 3.0.0-alpha.18-main-pg-client-downgrade
+        version: 3.0.0-alpha.18-main-pg-client-downgrade(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -700,28 +700,28 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-u9Dt7SyRNo758yt6rbOHhQAC0YMhJOQoWS22aP8xYJt74D2xyCQzvRDOOyYv6FG1DGXXZ4pE396/MFvpddbpDg==}
+  envio-darwin-arm64@3.0.0-alpha.18-main-pg-client-downgrade:
+    resolution: {integrity: sha512-XohbYoEcSG7BlUdi4tdbKSKvt4GKMgjrqGbdIVNydO77gsjlTCJa/+FYkHY83F3pgHrOz+YzcfesgGbjVsfy0A==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-d18zc+5gHdupMIVMZPcuWUciC2ALDD/eWpAhXiQFv7Bg3zsng44vTw0Bjd8MyUkcUBOTl1zPgvNG3pjnUpRk3A==}
+  envio-darwin-x64@3.0.0-alpha.18-main-pg-client-downgrade:
+    resolution: {integrity: sha512-aIxITk2xYgGAmT/UHmUeXHGQcK3jP1qIwH+bx4FmbE5adYEJy7J9+2BJo4ajBGElPy4H6meosl4yaWSbOwhdqQ==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-/KNgYN8/IIMAWKTAPftlJBRxFiGt21AKPuKc/+c5iEqiqenoU+gsBxSzXLPm7/EyvgBmd9uOA6hHzJyOLU8KGA==}
+  envio-linux-arm64@3.0.0-alpha.18-main-pg-client-downgrade:
+    resolution: {integrity: sha512-ThFzOqsxcoNOdTV9jAjMdtta1v3kTaNU/JYjSP87rIcBIu3MY09Avu4xExjOU/D9KRX0Ehk4ZqFBCKcw4tdj9A==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-MzlIdk/Ta1cSa/n2u+8hwL5p9EGCKB0yClw9Pag/GIrS+2ANaRD/miSWagolh6VjB1z01IEAMgXVGQWrCVlDGA==}
+  envio-linux-x64@3.0.0-alpha.18-main-pg-client-downgrade:
+    resolution: {integrity: sha512-DpMXHiYT+pmG/0nkK5AX2DsZfg2SG4RG4CBe6R3tIXTaW+fUsM1ACDLTEPVZtIhXl9skaLfARVTeMlyLv5Rh/A==}
     cpu: [x64]
     os: [linux]
 
-  envio@3.0.0-alpha.18:
-    resolution: {integrity: sha512-sts1EucywUmNPZJqJ+bWYmEY2bkfeHtTstHb6vrCxQLu+AM3wRr2WUKSHViDk0ISJTR/yW4ZHXgsek/lEXQ7Mg==}
+  envio@3.0.0-alpha.18-main-pg-client-downgrade:
+    resolution: {integrity: sha512-84wVfcMAROiOJ7xwXFmbauwDmzOv0j9C/mn0QtBSARr7MzuL3ZxckmbEMs5RhtMClqNB0aynpUmMfw2jD0T2Og==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1099,8 +1099,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgres@3.4.8:
-    resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
+  postgres@3.4.1:
+    resolution: {integrity: sha512-Wasjv6WEzrZXbwKByR2RGD7MBfj7VBqco3hYWz8ifzSAp6tb2L6MlmcKFzkmgV1jT7/vKlcSa+lxXZeTdeVMzQ==}
     engines: {node: '>=12'}
 
   process-warning@5.0.0:
@@ -2002,19 +2002,19 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.0.0-alpha.18:
+  envio-darwin-arm64@3.0.0-alpha.18-main-pg-client-downgrade:
     optional: true
 
-  envio-darwin-x64@3.0.0-alpha.18:
+  envio-darwin-x64@3.0.0-alpha.18-main-pg-client-downgrade:
     optional: true
 
-  envio-linux-arm64@3.0.0-alpha.18:
+  envio-linux-arm64@3.0.0-alpha.18-main-pg-client-downgrade:
     optional: true
 
-  envio-linux-x64@3.0.0-alpha.18:
+  envio-linux-x64@3.0.0-alpha.18-main-pg-client-downgrade:
     optional: true
 
-  envio@3.0.0-alpha.18(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  envio@3.0.0-alpha.18-main-pg-client-downgrade(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2031,7 +2031,7 @@ snapshots:
       ink-spinner: 5.0.0(ink@6.8.0(react@19.2.3))(react@19.2.3)
       pino: 10.3.1
       pino-pretty: 13.1.3
-      postgres: 3.4.8
+      postgres: 3.4.1
       prom-client: 15.1.3
       rescript: 11.1.3
       rescript-envsafe: 5.0.0(rescript-schema@9.3.4(rescript@11.1.3))(rescript@11.1.3)
@@ -2040,10 +2040,10 @@ snapshots:
       viem: 2.46.2(typescript@5.9.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.0-alpha.18
-      envio-darwin-x64: 3.0.0-alpha.18
-      envio-linux-arm64: 3.0.0-alpha.18
-      envio-linux-x64: 3.0.0-alpha.18
+      envio-darwin-arm64: 3.0.0-alpha.18-main-pg-client-downgrade
+      envio-darwin-x64: 3.0.0-alpha.18-main-pg-client-downgrade
+      envio-linux-arm64: 3.0.0-alpha.18-main-pg-client-downgrade
+      envio-linux-x64: 3.0.0-alpha.18-main-pg-client-downgrade
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2463,7 +2463,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres@3.4.8: {}
+  postgres@3.4.1: {}
 
   process-warning@5.0.0: {}
 


### PR DESCRIPTION
## Summary
Updated the envio dependency to use a PostgreSQL client downgrade variant for the ERC20 transfer events example project.

## Changes
- Updated `envio` dependency from `3.0.0-alpha.18` to `3.0.0-alpha.18-main-pg-client-downgrade` in the package.json

## Details
This change pins the envio package to a specific variant that includes a PostgreSQL client downgrade, likely to address compatibility issues or performance concerns with the current pg client version used in the indexer.

https://claude.ai/code/session_01U7EZAngpugRACHF2pULNzx