### PR TITLE
Upgrade envio dependency to 3.0.0-alpha.19

### DIFF
--- a/cases/erc20-transfer-events/envio/package.json
+++ b/cases/erc20-transfer-events/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.0.16"
   },
   "dependencies": {
-    "envio": "3.0.0-alpha.18"
+    "envio": "3.0.0-alpha.19"
   },
   "optionalDependencies": {
     "generated": "./generated"

--- a/cases/erc20-transfer-events/envio/pnpm-lock.yaml
+++ b/cases/erc20-transfer-events/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.0.0-alpha.18
-        version: 3.0.0-alpha.18(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        specifier: 3.0.0-alpha.19
+        version: 3.0.0-alpha.19(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -700,28 +700,28 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-u9Dt7SyRNo758yt6rbOHhQAC0YMhJOQoWS22aP8xYJt74D2xyCQzvRDOOyYv6FG1DGXXZ4pE396/MFvpddbpDg==}
+  envio-darwin-arm64@3.0.0-alpha.19:
+    resolution: {integrity: sha512-PExo4Ioq01VrAvAVZ/JokLJoMUsCTJjTLZ751xUSD1dQIcB90pNgKrL2GOYG5o2b/AWn4ifu4sl0D9kk4nEAfw==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-d18zc+5gHdupMIVMZPcuWUciC2ALDD/eWpAhXiQFv7Bg3zsng44vTw0Bjd8MyUkcUBOTl1zPgvNG3pjnUpRk3A==}
+  envio-darwin-x64@3.0.0-alpha.19:
+    resolution: {integrity: sha512-/ZmSTe/av+4Ulu02dkki8oKYqKIGjPO472PdGoeP8DOoBTRXCY4r7tPYBFdjk7NY2lEcM2ysalbeca0p0UnEtw==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-/KNgYN8/IIMAWKTAPftlJBRxFiGt21AKPuKc/+c5iEqiqenoU+gsBxSzXLPm7/EyvgBmd9uOA6hHzJyOLU8KGA==}
+  envio-linux-arm64@3.0.0-alpha.19:
+    resolution: {integrity: sha512-uNairDh9enf9tWGFfY6JPNiuJKoD7zjPeyoZFLKsZiMropXHvEHI5r8Z6KTYfkrUIYj0q1s6Y5cjVfugsrYYmQ==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@3.0.0-alpha.18:
-    resolution: {integrity: sha512-MzlIdk/Ta1cSa/n2u+8hwL5p9EGCKB0yClw9Pag/GIrS+2ANaRD/miSWagolh6VjB1z01IEAMgXVGQWrCVlDGA==}
+  envio-linux-x64@3.0.0-alpha.19:
+    resolution: {integrity: sha512-egC/u8rUNfVD8pmi0p0CvO6bMIRIH3BDTZ4vYYmTJxbUc+NLS9BFxYiiMYFHeXehKJVSOKlIgj7PsvgB+G4WrQ==}
     cpu: [x64]
     os: [linux]
 
-  envio@3.0.0-alpha.18:
-    resolution: {integrity: sha512-sts1EucywUmNPZJqJ+bWYmEY2bkfeHtTstHb6vrCxQLu+AM3wRr2WUKSHViDk0ISJTR/yW4ZHXgsek/lEXQ7Mg==}
+  envio@3.0.0-alpha.19:
+    resolution: {integrity: sha512-56GwwghlqvQBEIPWegnSHb0lyv/pS6t/GWqE7eom0DK0qGLM/AdUv9epDlhFDI+mN132gYVOOpqxbwsa5Qu7cQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2002,19 +2002,19 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.0.0-alpha.18:
+  envio-darwin-arm64@3.0.0-alpha.19:
     optional: true
 
-  envio-darwin-x64@3.0.0-alpha.18:
+  envio-darwin-x64@3.0.0-alpha.19:
     optional: true
 
-  envio-linux-arm64@3.0.0-alpha.18:
+  envio-linux-arm64@3.0.0-alpha.19:
     optional: true
 
-  envio-linux-x64@3.0.0-alpha.18:
+  envio-linux-x64@3.0.0-alpha.19:
     optional: true
 
-  envio@3.0.0-alpha.18(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  envio@3.0.0-alpha.19(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2040,10 +2040,10 @@ snapshots:
       viem: 2.46.2(typescript@5.9.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.0-alpha.18
-      envio-darwin-x64: 3.0.0-alpha.18
-      envio-linux-arm64: 3.0.0-alpha.18
-      envio-linux-x64: 3.0.0-alpha.18
+      envio-darwin-arm64: 3.0.0-alpha.19
+      envio-darwin-x64: 3.0.0-alpha.19
+      envio-linux-arm64: 3.0.0-alpha.19
+      envio-linux-x64: 3.0.0-alpha.19
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil


### PR DESCRIPTION
## Summary
Updates the envio package dependency to the latest alpha version in the ERC20 transfer events example project.

## Changes
- Bumped `envio` from `3.0.0-alpha.18` to `3.0.0-alpha.19` in package.json

## Details
This is a routine dependency update to incorporate the latest improvements and fixes from the envio alpha release cycle.

https://claude.ai/code/session_015RLazt8aUFi5wmUw3VheFS