### PR TITLE
Upgrade envio to v3.1.0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -208,7 +208,6 @@ jobs:
 
             const resultsDir = 'results';
             const results = [];
-            const outputs = [];
 
             const SUMMARY_RE = /Summary — (.+?): ([\d,.]+) blocks\/s, ([\d,.]+) events\/s/;
             const stripDurationTag = name => name.replace(/\s\(\d+s\)$/, '');
@@ -218,7 +217,6 @@ jobs:
                 const file = path.join(resultsDir, dir, 'benchmark-output.txt');
                 if (!fs.existsSync(file)) continue;
                 const content = fs.readFileSync(file, 'utf8');
-                outputs.push(content);
 
                 const match = content.match(SUMMARY_RE);
                 if (match) {
@@ -249,20 +247,14 @@ jobs:
               table = [header, sep, blocksRow, eventsRow].join('\n');
             }
 
-            const fullOutput = outputs.join('\n\n---\n\n') || 'No benchmark output captured.';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const body = [
               '## Benchmark Results: ERC20 Transfer Events',
               '',
               table,
               '',
-              '<details><summary>Full output</summary>',
-              '',
-              '```',
-              fullOutput,
-              '```',
-              '',
-              '</details>'
+              `[Full output](${runUrl}) is available in the workflow run logs.`,
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -142,7 +142,6 @@ jobs:
 
             const resultsDir = 'results';
             const results = [];
-            const outputs = [];
 
             // Summary lines look like:
             //   "Summary — Envio (40s): 77,177.0 blocks/s, 9,984.0 events/s"
@@ -158,7 +157,6 @@ jobs:
                 const file = path.join(resultsDir, dir, 'benchmark-output.txt');
                 if (!fs.existsSync(file)) continue;
                 const content = fs.readFileSync(file, 'utf8');
-                outputs.push(content);
 
                 const match = content.match(SUMMARY_RE);
                 if (match) {
@@ -204,48 +202,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = require('path');
 
-            const resultsDir = 'results';
-            const results = [];
-
-            const SUMMARY_RE = /Summary — (.+?): ([\d,.]+) blocks\/s, ([\d,.]+) events\/s/;
-            const stripDurationTag = name => name.replace(/\s\(\d+s\)$/, '');
-
-            if (fs.existsSync(resultsDir)) {
-              for (const dir of fs.readdirSync(resultsDir).sort()) {
-                const file = path.join(resultsDir, dir, 'benchmark-output.txt');
-                if (!fs.existsSync(file)) continue;
-                const content = fs.readFileSync(file, 'utf8');
-
-                const match = content.match(SUMMARY_RE);
-                if (match) {
-                  results.push({
-                    name: stripDurationTag(match[1]),
-                    blocksPerSec: parseFloat(match[2].replace(/,/g, '')),
-                    eventsPerSec: parseFloat(match[3].replace(/,/g, '')),
-                  });
-                }
-              }
-            }
-
-            let table = '_No results collected._';
-            if (results.length > 0) {
-              results.sort((a, b) => b.blocksPerSec - a.blocksPerSec);
-              const firstRate = results[0].blocksPerSec;
-              const fmtRate = n => n.toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
-              const label = (r, i) => {
-                if (i === 0 || results.length === 1) return r.name;
-                const ratio = firstRate / r.blocksPerSec;
-                const n = ratio % 1 === 0 ? String(Math.round(ratio)) : ratio.toFixed(1);
-                return `${r.name} (${n}x slower)`;
-              };
-              const header = `| | ${results.map((r, i) => label(r, i)).join(' | ')} |`;
-              const sep = `| --- | ${results.map(() => '---').join(' | ')} |`;
-              const blocksRow = `| blocks/s | ${results.map(r => fmtRate(r.blocksPerSec)).join(' | ')} |`;
-              const eventsRow = `| events/s | ${results.map(r => fmtRate(r.eventsPerSec)).join(' | ')} |`;
-              table = [header, sep, blocksRow, eventsRow].join('\n');
-            }
+            // The table was already built and saved by the previous step.
+            const table = fs.existsSync('/tmp/benchmark-table.md')
+              ? fs.readFileSync('/tmp/benchmark-table.md', 'utf8')
+              : '_No results collected._';
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 

--- a/cases/erc20-transfer-events/envio/.gitignore
+++ b/cases/erc20-transfer-events/envio/.gitignore
@@ -33,4 +33,5 @@ cache
 *.res.mjs
 generated
 .envio
+envio-env.d.ts
 .env

--- a/cases/erc20-transfer-events/envio/package.json
+++ b/cases/erc20-transfer-events/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.1.6"
   },
   "dependencies": {
-    "envio": "3.0.0"
+    "envio": "3.1.0-rc.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/cases/erc20-transfer-events/envio/package.json
+++ b/cases/erc20-transfer-events/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.1.6"
   },
   "dependencies": {
-    "envio": "3.1.0-rc.1"
+    "envio": "3.1.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/cases/erc20-transfer-events/envio/pnpm-lock.yaml
+++ b/cases/erc20-transfer-events/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.1.0-rc.1
-        version: 3.1.0-rc.1(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.1.0
+        version: 3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
@@ -713,36 +713,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.1.0-rc.1:
-    resolution: {integrity: sha512-5z5FNsJXZ163E4Gxim2uSh8GswDqQk3AC0dbPtifneM8s5Q32EOIr9i0Pxk2OWyrt61obZCvboEBGCsIBO/2cA==}
+  envio-darwin-arm64@3.1.0:
+    resolution: {integrity: sha512-6oY9/J7HrG/d6hGKfjgM8WqttkT5ECYtHRtxzOxzQBm+NqGAuJX+8ev/xSP5juKAayYu2z6K1XYGg0wSGNT6dw==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.1.0-rc.1:
-    resolution: {integrity: sha512-gkHHFruyeCRVw6JF9y4J9+RaiOJfAajfdnU+viYoaISFOQhpM2/yb7MqxLQrpBUwjlQd2F5w8qSIucxZ8hdo9w==}
+  envio-darwin-x64@3.1.0:
+    resolution: {integrity: sha512-I03Fcww7zUNoX+RsPnh6MsoOw/Mramt6NDhA1k/6kcp0ttjAEAFbptw50yiQ2D1RFllj0j6J7GiiEBCu1Qc77w==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.1.0-rc.1:
-    resolution: {integrity: sha512-VzFdQUkrdXkixQ1MAq8E6uVAhyFk5WlF1EPZlBAvxc6u/EZ1KvLu0CUXU8Hh8Wfa6c1sYJCwj4JpVlw/4VVZAg==}
+  envio-linux-arm64@3.1.0:
+    resolution: {integrity: sha512-DAAHrNref4vR3+JC+/2rkvjG34bpOdRqbEMH9NBvyMF0Fwjh1Y5S1tWhoUTlYC20vdq4pRasKt2oFeCGxmWziQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.1.0-rc.1:
-    resolution: {integrity: sha512-wgWY6vmCmxd2xZBDtwvYxn1CwQHG63YC8lF1wz0GCr0jGe0/ZJ8PVs6T+rrjWtGTIW8XKgYMtd5GCdsZN0HF4w==}
+  envio-linux-x64-musl@3.1.0:
+    resolution: {integrity: sha512-TmhEWtzMYrlypaozzaVGJLPedlOseQ4q7WWqfmFzlJXbMdAxAT0len3SDQJZCZfb8ooLN/ck6kUUE0C2HTJo1w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.1.0-rc.1:
-    resolution: {integrity: sha512-rXUBaJPrUB1jJCYd1+XQ1HspYJobMDpGqmeHihLPjx6U37HtEN1VbG85jvHH72YiQyHjRohA8o4m4nNgZMqE2g==}
+  envio-linux-x64@3.1.0:
+    resolution: {integrity: sha512-Oe7SzfQJXC/jqJHbEsjqUiluCSdVol/EYda2wmrqxwQKNifYWdodcPCG+T8jNHMSkXLDVXO6990pLNmmMy4HpQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.1.0-rc.1:
-    resolution: {integrity: sha512-+ahfaVHKEYMa9jHlLshIRo7evqRQ5mRrn8hj/A0TqxzHShaFveucrZEo568sWR7F75jEafVvIpkOEil5C5kJZw==}
+  envio@3.1.0:
+    resolution: {integrity: sha512-58b5f/mXYQjHTd4STNYpjRlLqTA32mRrAWaHYsX4yEFZq4QlHO05CRnaA7H4xCRP42XQviI6lzspAH6g5nSViA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2069,22 +2069,22 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.1.0-rc.1:
+  envio-darwin-arm64@3.1.0:
     optional: true
 
-  envio-darwin-x64@3.1.0-rc.1:
+  envio-darwin-x64@3.1.0:
     optional: true
 
-  envio-linux-arm64@3.1.0-rc.1:
+  envio-linux-arm64@3.1.0:
     optional: true
 
-  envio-linux-x64-musl@3.1.0-rc.1:
+  envio-linux-x64-musl@3.1.0:
     optional: true
 
-  envio-linux-x64@3.1.0-rc.1:
+  envio-linux-x64@3.1.0:
     optional: true
 
-  envio@3.1.0-rc.1(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
+  envio@3.1.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2115,11 +2115,11 @@ snapshots:
       viem: 2.46.2(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.1.0-rc.1
-      envio-darwin-x64: 3.1.0-rc.1
-      envio-linux-arm64: 3.1.0-rc.1
-      envio-linux-x64: 3.1.0-rc.1
-      envio-linux-x64-musl: 3.1.0-rc.1
+      envio-darwin-arm64: 3.1.0
+      envio-darwin-x64: 3.1.0
+      envio-linux-arm64: 3.1.0
+      envio-linux-x64: 3.1.0
+      envio-linux-x64-musl: 3.1.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/cases/erc20-transfer-events/envio/pnpm-lock.yaml
+++ b/cases/erc20-transfer-events/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.0.0
-        version: 3.0.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.1.0-rc.1
+        version: 3.1.0-rc.1(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
@@ -87,43 +87,6 @@ packages:
 
   '@envio-dev/hyperfuel-client@1.2.2':
     resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
-
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    resolution: {integrity: sha512-JZwiVRbMSuJnKsVUpfjTHc3YgAMvGlyuqWQxVc7Eok4Xp/sZLUCXRQUykbCh6fOUWRmoa2JG/ykP/NotoTRCBg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    resolution: {integrity: sha512-2eSzQqqqFBMK2enVucYGcny5Ep4DEKYxf3Xme7z9qp2d3c6fMcbVvM4Gt8KOzb7ySjwJ2gU+qY2h545T2NiJXQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    resolution: {integrity: sha512-gsjMp3WKekwnA89HvJXvcTM3BE5wVFG/qTF4rmk3rGiXhZ+MGaZQKrYRAhnzQZblueFtF/xnnBYpO35Z3ZFThg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    resolution: {integrity: sha512-Lkvi4lRVwCyFOXf9LYH2X91zmW2l1vbfojKhTwKgqFWv6PMN5atlYjt+/NcUCAAhk5EUavWGjoikwnvLp870cg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    resolution: {integrity: sha512-UIjB/gUX2sl23EMXLBxqtkgMnOjNSiaHK+CSU5vXMXkzL3fOGbz24bvyaPsSv82cxCFEE0yTwlSKkCX6/L8o6Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hypersync-client@1.3.0':
-    resolution: {integrity: sha512-wUdfZzbsFPbGq6n/1mmUMsWuiAil+m+fL/GBX5LGUyMJV86TXy2SBtAqYYNyDxWLO6gvGr6PYKrP8pLVAUZDZg==}
     engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.27.3':
@@ -750,36 +713,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.0.0:
-    resolution: {integrity: sha512-kjnTXRSuc/UnPAuqGDxiffgCXM7ERJqTPUZGUWBACzYfki8Ai6U/izapU5cKZLAEOlI3V8GnRViUntdIvKI8HA==}
+  envio-darwin-arm64@3.1.0-rc.1:
+    resolution: {integrity: sha512-5z5FNsJXZ163E4Gxim2uSh8GswDqQk3AC0dbPtifneM8s5Q32EOIr9i0Pxk2OWyrt61obZCvboEBGCsIBO/2cA==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.0:
-    resolution: {integrity: sha512-9wnPKWO3R7ex82nu13lPfmvgi2jsWOJ7s7IvPoH7hLmWbmBAdhP1cGEPPsTWwJVl4I0uB+ymAoP9HZvDMGOQjQ==}
+  envio-darwin-x64@3.1.0-rc.1:
+    resolution: {integrity: sha512-gkHHFruyeCRVw6JF9y4J9+RaiOJfAajfdnU+viYoaISFOQhpM2/yb7MqxLQrpBUwjlQd2F5w8qSIucxZ8hdo9w==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.0.0:
-    resolution: {integrity: sha512-G92c8/JQxB1THj3QUpJ8SjIKDFhB/0XQLInBrGg4nGBXUXavgNpot98Qm+rw+tiPZJNsRIbqAjDSwoQNWpLPbw==}
+  envio-linux-arm64@3.1.0-rc.1:
+    resolution: {integrity: sha512-VzFdQUkrdXkixQ1MAq8E6uVAhyFk5WlF1EPZlBAvxc6u/EZ1KvLu0CUXU8Hh8Wfa6c1sYJCwj4JpVlw/4VVZAg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.0.0:
-    resolution: {integrity: sha512-qdROseEZRoVlQHPtZrMM76pAfdBTqZxNLTkMZl/r4PlVQ6B0KTYkU7fNFytaV8KPVqT7sfsjY2eF+QloBKVAzw==}
+  envio-linux-x64-musl@3.1.0-rc.1:
+    resolution: {integrity: sha512-wgWY6vmCmxd2xZBDtwvYxn1CwQHG63YC8lF1wz0GCr0jGe0/ZJ8PVs6T+rrjWtGTIW8XKgYMtd5GCdsZN0HF4w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.0.0:
-    resolution: {integrity: sha512-2ciq4EUANqYFxKDfy6/Ocr7fhathR64qDIVQaii2GK8eaLSZRt1G2qb0niDx6ixyeBPXHHEjGqsZ70i4UH0bBQ==}
+  envio-linux-x64@3.1.0-rc.1:
+    resolution: {integrity: sha512-rXUBaJPrUB1jJCYd1+XQ1HspYJobMDpGqmeHihLPjx6U37HtEN1VbG85jvHH72YiQyHjRohA8o4m4nNgZMqE2g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.0.0:
-    resolution: {integrity: sha512-GhLPCJJHZzQji1Kg0UtVy7IH3IRVonSJsSk6Xeybsw7rT1FFpHbLM8FxF95Ccmvw3IUnQGfvmw3t+TyerUFO6A==}
+  envio@3.1.0-rc.1:
+    resolution: {integrity: sha512-+ahfaVHKEYMa9jHlLshIRo7evqRQ5mRrn8hj/A0TqxzHShaFveucrZEo568sWR7F75jEafVvIpkOEil5C5kJZw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1643,29 +1606,6 @@ snapshots:
       '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
       '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
-  '@envio-dev/hypersync-client-darwin-arm64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-darwin-x64@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-arm64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-gnu@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client-linux-x64-musl@1.3.0':
-    optional: true
-
-  '@envio-dev/hypersync-client@1.3.0':
-    optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 1.3.0
-      '@envio-dev/hypersync-client-darwin-x64': 1.3.0
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-gnu': 1.3.0
-      '@envio-dev/hypersync-client-linux-x64-musl': 1.3.0
-
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -2129,27 +2069,26 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.0.0:
+  envio-darwin-arm64@3.1.0-rc.1:
     optional: true
 
-  envio-darwin-x64@3.0.0:
+  envio-darwin-x64@3.1.0-rc.1:
     optional: true
 
-  envio-linux-arm64@3.0.0:
+  envio-linux-arm64@3.1.0-rc.1:
     optional: true
 
-  envio-linux-x64-musl@3.0.0:
+  envio-linux-x64-musl@3.1.0-rc.1:
     optional: true
 
-  envio-linux-x64@3.0.0:
+  envio-linux-x64@3.1.0-rc.1:
     optional: true
 
-  envio@3.0.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
+  envio@3.1.0-rc.1(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
       '@envio-dev/hyperfuel-client': 1.2.2
-      '@envio-dev/hypersync-client': 1.3.0
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -2176,11 +2115,11 @@ snapshots:
       viem: 2.46.2(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.0
-      envio-darwin-x64: 3.0.0
-      envio-linux-arm64: 3.0.0
-      envio-linux-x64: 3.0.0
-      envio-linux-x64-musl: 3.0.0
+      envio-darwin-arm64: 3.1.0-rc.1
+      envio-darwin-x64: 3.1.0-rc.1
+      envio-linux-arm64: 3.1.0-rc.1
+      envio-linux-x64: 3.1.0-rc.1
+      envio-linux-x64-musl: 3.1.0-rc.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil


### PR DESCRIPTION
## Summary

Upgrades the `envio` (HyperIndex) dependency in the `erc20-transfer-events` benchmark case from `3.0.0` to the stable [`v3.1.0`](https://github.com/enviodev/hyperindex/releases/tag/v3.1.0) release.

## Changes

- Bumped `envio` to `3.1.0` in `cases/erc20-transfer-events/envio/package.json`
- Regenerated `pnpm-lock.yaml`
- Added `envio-env.d.ts` to `.gitignore` — a new codegen artifact introduced in 3.1.0 (it wires project types from the gitignored `.envio/types.d.ts` into the `envio` module and is regenerated by `envio codegen`, which CI already runs)
- Fixed a pre-existing CI failure in the "Comment results on PR" step: it embedded the full concatenated benchmark logs (~290k chars) in the PR comment, exceeding GitHub's 65,536-char limit. The comment now contains the results table plus a link to the workflow run logs.

## Verification

- `pnpm install` succeeds against the new lockfile
- `pnpm codegen` runs successfully (exit 0) with the new version
- All benchmark jobs pass in CI (envio 3.1.0: ~97k blocks/s, ~12k events/s)

https://claude.ai/code/session_012QKfBPzxZXsCHgPf4UfGBh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency from 3.0.0 to 3.1.0 to pick up minor improvements.
  * Ignored a generated declaration file so it’s no longer tracked, reducing repository noise.
  * Simplified benchmark workflow output in PR comments: comments now include a compact results table and a link to full run logs instead of embedding raw output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->