### PR TITLE
Improve rindexer installation reliability and carry forward stale results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -238,7 +238,10 @@ jobs:
                 else if (/^events\/s$/i.test(c[0])) events = c;
               }
               if (!header || !blocks || !events) return {};
-              const names = header.slice(1).map(n => n.replace(/\s*\(\d+(?:\.\d+)?x slower\)\s*$/, '').trim());
+              const names = header.slice(1).map(n => n
+                .replace(/\s*⚠️\s*$/, '')
+                .replace(/\s*\(\d+(?:\.\d+)?x slower\)\s*$/, '')
+                .trim());
               const out = {};
               for (let i = 0; i < names.length; i++) {
                 const b = parseFloat((blocks[i + 1] || '').replace(/,/g, ''));
@@ -284,7 +287,7 @@ jobs:
               const carried = [];
               for (const [name, vals] of Object.entries(prior)) {
                 if (!haveNames.has(name)) {
-                  results.push({ name, blocksPerSec: vals.blocksPerSec, eventsPerSec: vals.eventsPerSec });
+                  results.push({ name, blocksPerSec: vals.blocksPerSec, eventsPerSec: vals.eventsPerSec, carriedOver: true });
                   carried.push(name);
                 }
               }
@@ -304,22 +307,30 @@ jobs:
               const firstRate = results[0].blocksPerSec;
               const fmtRate = n => n.toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
               const label = (r, i) => {
-                if (i === 0 || results.length === 1) return r.name;
-                const ratio = firstRate / r.blocksPerSec;
-                const n = ratio % 1 === 0 ? String(Math.round(ratio)) : ratio.toFixed(1);
-                return `${r.name} (${n}x slower)`;
+                let s;
+                if (i === 0 || results.length === 1) {
+                  s = r.name;
+                } else {
+                  const ratio = firstRate / r.blocksPerSec;
+                  const n = ratio % 1 === 0 ? String(Math.round(ratio)) : ratio.toFixed(1);
+                  s = `${r.name} (${n}x slower)`;
+                }
+                // Flag carried-forward columns as stale in the rendered table.
+                return r.carriedOver ? `${s} ⚠️` : s;
               };
 
               const header = `| | ${results.map((r, i) => label(r, i)).join(' | ')} |`;
               const sep = `| --- | ${results.map(() => '---').join(' | ')} |`;
               const blocksRow = `| blocks/s | ${results.map(r => fmtRate(r.blocksPerSec)).join(' | ')} |`;
               const eventsRow = `| events/s | ${results.map(r => fmtRate(r.eventsPerSec)).join(' | ')} |`;
-              const table = [header, sep, blocksRow, eventsRow].join('\n');
+              let table = [header, sep, blocksRow, eventsRow].join('\n');
+              if (carried.length) {
+                // Explain the ⚠️ marker right under the table so it travels with
+                // the README, PR comment, and job summary alike.
+                table += `\n\n> ⚠️ ${carried.join(', ')} — carried forward from a previous run; the latest run produced no fresh result.`;
+              }
 
               core.summary.addRaw(`## ${heading} Benchmark\n\n${table}\n`);
-              if (carried.length) {
-                core.summary.addRaw(`\n> ⚠️ Carried forward last published value(s) for **${carried.join(', ')}** — no fresh result this run.\n`);
-              }
               fs.writeFileSync(`/tmp/benchmark-table-${benchCase}.md`, table);
             }
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -95,6 +95,8 @@ jobs:
           node-version: 24
 
       - name: Prepare services
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           INDEXER="${{ matrix.indexer }}"
           CASE_DIR="cases/${{ matrix.case }}"
@@ -106,7 +108,30 @@ jobs:
               ;;
             rindexer)
               docker compose -f "$CASE_DIR/rindexer/docker-compose.yml" pull
-              curl -L https://rindexer.xyz/install.sh | bash
+              # install.sh resolves "latest" via an UNAUTHENTICATED GitHub API
+              # call (60 req/h, shared across Actions runners) and does not guard
+              # an empty result: when throttled the version is blank and the
+              # download URL 404s (".../releases/download/v/..."), failing the job
+              # and silently dropping rindexer from the table. Resolve the tag
+              # ourselves with an authenticated call (5000 req/h) and pin it via
+              # --version, which still tracks the latest release.
+              RINDEXER_VERSION=""
+              for i in 1 2 3; do
+                RINDEXER_VERSION=$(curl -fsSL \
+                  -H "Authorization: Bearer $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  https://api.github.com/repos/joshstevens19/rindexer/releases/latest \
+                  | jq -r '.tag_name // empty' | sed 's/^v//') || true
+                [ -n "$RINDEXER_VERSION" ] && break
+                echo "rindexer version lookup attempt $i failed; retrying..." >&2
+                sleep $((i * 5))
+              done
+              if [ -z "$RINDEXER_VERSION" ]; then
+                echo "Failed to resolve latest rindexer version" >&2
+                exit 1
+              fi
+              echo "Installing rindexer v$RINDEXER_VERSION"
+              curl -L https://rindexer.xyz/install.sh | bash -s -- --version "$RINDEXER_VERSION"
               ;;
             subquery)
               docker compose -f "$CASE_DIR/subquery/docker-compose.yml" pull
@@ -173,6 +198,13 @@ jobs:
             const cases = JSON.parse(process.env.CASES);
             const resultsDir = 'results';
 
+            // The checked-out README holds the currently published tables; we
+            // read it so we can carry forward any indexer that produced no fresh
+            // result this run (see the carry-forward block below).
+            const readmeText = fs.existsSync('README.md')
+              ? fs.readFileSync('README.md', 'utf8')
+              : '';
+
             // Summary lines look like:
             //   "Summary — Envio (40s): 77,177.0 blocks/s, 9,984.0 events/s"
             //   "Summary — Ponder: 502.0 blocks/s, 44.0 events/s"
@@ -184,6 +216,39 @@ jobs:
 
             const titleCase = c =>
               c.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+            // Extract { name: {blocksPerSec, eventsPerSec} } from a case's
+            // published table (between its BENCHMARK markers in the README), so a
+            // missing indexer can be carried forward instead of silently dropped.
+            const parsePublishedTable = (md, benchCase) => {
+              const startMarker = `<!-- BENCHMARK:${benchCase}:START -->`;
+              const endMarker = `<!-- BENCHMARK:${benchCase}:END -->`;
+              const start = md.indexOf(startMarker);
+              const end = md.indexOf(endMarker);
+              if (start === -1 || end === -1 || end < start) return {};
+              const rows = md.slice(start + startMarker.length, end)
+                .split('\n')
+                .filter(l => l.trim().startsWith('|'));
+              const cellsOf = l => l.split('|').slice(1, -1).map(s => s.trim());
+              let header, blocks, events;
+              for (const l of rows) {
+                const c = cellsOf(l);
+                if (c[0] === '') header = c;
+                else if (/^blocks\/s$/i.test(c[0])) blocks = c;
+                else if (/^events\/s$/i.test(c[0])) events = c;
+              }
+              if (!header || !blocks || !events) return {};
+              const names = header.slice(1).map(n => n.replace(/\s*\(\d+(?:\.\d+)?x slower\)\s*$/, '').trim());
+              const out = {};
+              for (let i = 0; i < names.length; i++) {
+                const b = parseFloat((blocks[i + 1] || '').replace(/,/g, ''));
+                const e = parseFloat((events[i + 1] || '').replace(/,/g, ''));
+                if (names[i] && Number.isFinite(b) && Number.isFinite(e)) {
+                  out[names[i]] = { blocksPerSec: b, eventsPerSec: e };
+                }
+              }
+              return out;
+            };
 
             // Artifact dirs are named "benchmark-<case>--<indexer>".
             const dirs = fs.existsSync(resultsDir)
@@ -211,6 +276,25 @@ jobs:
 
               const heading = titleCase(benchCase);
 
+              // Carry forward any previously published indexer with no fresh
+              // result this run (failed job / no Summary line). Rebuilding the
+              // table only from successful runs would silently drop the column.
+              const prior = parsePublishedTable(readmeText, benchCase);
+              const haveNames = new Set(results.map(r => r.name));
+              const carried = [];
+              for (const [name, vals] of Object.entries(prior)) {
+                if (!haveNames.has(name)) {
+                  results.push({ name, blocksPerSec: vals.blocksPerSec, eventsPerSec: vals.eventsPerSec });
+                  carried.push(name);
+                }
+              }
+              if (carried.length) {
+                core.warning(
+                  `${heading}: no fresh result for ${carried.join(', ')} this run — ` +
+                  `carried forward the last published value(s). Check the failed benchmark job(s).`
+                );
+              }
+
               if (results.length === 0) {
                 core.summary.addRaw(`## ${heading} Benchmark\n\n_No results collected._\n`);
                 continue;
@@ -233,6 +317,9 @@ jobs:
               const table = [header, sep, blocksRow, eventsRow].join('\n');
 
               core.summary.addRaw(`## ${heading} Benchmark\n\n${table}\n`);
+              if (carried.length) {
+                core.summary.addRaw(`\n> ⚠️ Carried forward last published value(s) for **${carried.join(', ')}** — no fresh result this run.\n`);
+              }
               fs.writeFileSync(`/tmp/benchmark-table-${benchCase}.md`, table);
             }
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ See the full breakdown in [./cases/erc20-account-balances/README.md](./cases/erc
 Results of indexing raw Transfer event logs from the USDC token contract on Ethereum Mainnet, starting at block 18,600,000. Stores every decoded Transfer event with no aggregation — a pure write-only ingestion throughput test.
 
 <!-- BENCHMARK:erc20-transfer-events:START -->
-| | Envio | Sqd (2.8x slower) | Rindexer (5.1x slower) | Envio - RPC (53.2x slower) | Ponder (283.9x slower) | SubQuery (1622.5x slower) |
+| | Envio | Sqd (2.8x slower) | Rindexer (5.1x slower) ⚠️ | Envio - RPC (53.2x slower) | Ponder (283.9x slower) | SubQuery (1622.5x slower) |
 | --- | --- | --- | --- | --- | --- | --- |
 | blocks/s | 5,678.7 | 2,063.1 | 1,117.8 | 106.7 | 20.0 | 3.5 |
 | events/s | 49,798.5 | 16,803.2 | 8,775.2 | 742.3 | 162.8 | 28.7 |
+
+> ⚠️ Rindexer — carried forward from a previous run; the latest run produced no fresh result.
 <!-- BENCHMARK:erc20-transfer-events:END -->
 
 See the full breakdown in [./cases/erc20-transfer-events/README.md](./cases/erc20-transfer-events/README.md).

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ See the full breakdown in [./cases/erc20-account-balances/README.md](./cases/erc
 Results of indexing raw Transfer event logs from the USDC token contract on Ethereum Mainnet, starting at block 18,600,000. Stores every decoded Transfer event with no aggregation — a pure write-only ingestion throughput test.
 
 <!-- BENCHMARK:erc20-transfer-events:START -->
-| | Envio | Sqd (2.8x slower) | Envio - RPC (53.2x slower) | Ponder (283.9x slower) | SubQuery (1622.5x slower) |
-| --- | --- | --- | --- | --- | --- |
-| blocks/s | 5,678.7 | 2,063.1 | 106.7 | 20.0 | 3.5 |
-| events/s | 49,798.5 | 16,803.2 | 742.3 | 162.8 | 28.7 |
+| | Envio | Sqd (2.8x slower) | Rindexer (5.1x slower) | Envio - RPC (53.2x slower) | Ponder (283.9x slower) | SubQuery (1622.5x slower) |
+| --- | --- | --- | --- | --- | --- | --- |
+| blocks/s | 5,678.7 | 2,063.1 | 1,117.8 | 106.7 | 20.0 | 3.5 |
+| events/s | 49,798.5 | 16,803.2 | 8,775.2 | 742.3 | 162.8 | 28.7 |
 <!-- BENCHMARK:erc20-transfer-events:END -->
 
 See the full breakdown in [./cases/erc20-transfer-events/README.md](./cases/erc20-transfer-events/README.md).

--- a/cases/erc20-account-balances/run.ts
+++ b/cases/erc20-account-balances/run.ts
@@ -395,9 +395,16 @@ async function benchmarkRindexer(rpcUrl: string): Promise<BenchmarkResult> {
   );
   if (!existsSync(rindexerBin)) {
     console.log("Installing rindexer CLI...\n");
+    // install.sh resolves "latest" via an unauthenticated GitHub API call that
+    // is occasionally throttled (empty version -> 404 download). Retry a few
+    // times so a transient hiccup doesn't fail the whole benchmark.
     await exec(
       "bash",
-      ["-c", "curl -L https://rindexer.xyz/install.sh | bash"],
+      [
+        "-c",
+        "for i in 1 2 3; do curl -L https://rindexer.xyz/install.sh | bash && break; " +
+          'echo "rindexer install attempt $i failed; retrying..." >&2; sleep $((i * 5)); done',
+      ],
       RINDEXER_DIR,
       rindexerEnv
     );

--- a/cases/erc20-transfer-events/run.ts
+++ b/cases/erc20-transfer-events/run.ts
@@ -392,9 +392,16 @@ async function benchmarkRindexer(rpcUrl: string): Promise<BenchmarkResult> {
   );
   if (!existsSync(rindexerBin)) {
     console.log("Installing rindexer CLI...\n");
+    // install.sh resolves "latest" via an unauthenticated GitHub API call that
+    // is occasionally throttled (empty version -> 404 download). Retry a few
+    // times so a transient hiccup doesn't fail the whole benchmark.
     await exec(
       "bash",
-      ["-c", "curl -L https://rindexer.xyz/install.sh | bash"],
+      [
+        "-c",
+        "for i in 1 2 3; do curl -L https://rindexer.xyz/install.sh | bash && break; " +
+          'echo "rindexer install attempt $i failed; retrying..." >&2; sleep $((i * 5)); done',
+      ],
       RINDEXER_DIR,
       rindexerEnv
     );


### PR DESCRIPTION
## Summary
This PR improves the reliability of the benchmark workflow by addressing GitHub API rate limiting issues with rindexer installation and implementing a mechanism to carry forward benchmark results when jobs fail, preventing indexers from silently disappearing from published tables.

## Key Changes

- **Rindexer installation robustness**: Replace the unauthenticated GitHub API call in `install.sh` with an authenticated call that has higher rate limits (5000 req/h vs 60 req/h). The version is now resolved explicitly and pinned via the `--version` flag, with retry logic to handle transient failures.
  - Updated `.github/workflows/benchmarks.yml` to pass `GITHUB_TOKEN` and implement a 3-attempt retry loop with exponential backoff
  - Updated `cases/erc20-account-balances/run.ts` and `cases/erc20-transfer-events/run.ts` with retry logic for the install script

- **Carry-forward mechanism for stale results**: When a benchmark job fails to produce fresh results for an indexer, the previous published values are now carried forward instead of silently dropping the column from the table.
  - Added `parsePublishedTable()` function to extract benchmark data from the existing README
  - Results marked as `carriedOver` are flagged with a ⚠️ warning in the table header
  - A warning message is logged and an explanatory note is added below the table
  - The workflow generates a warning in the job summary when results are carried forward

- **Updated README**: The erc20-transfer-events benchmark table now includes Rindexer results with a carried-forward indicator, demonstrating the new functionality.

## Implementation Details

- The authenticated GitHub API call uses `jq` to safely extract the tag name and handles empty results gracefully
- Retry logic uses exponential backoff (5s, 10s, 15s) to avoid overwhelming the API
- The carry-forward logic preserves the table structure and makes it clear which results are stale via visual indicators and explanatory text
- The solution maintains backward compatibility with the existing benchmark table format

https://claude.ai/code/session_01UPsYynHXXLLvb6dC63jHtu