### PR TITLE
Upgrade envio dependency to 3.3.0-alpha.6

### DIFF
--- a/cases/erc20-account-balances/envio/package.json
+++ b/cases/erc20-account-balances/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.1.6"
   },
   "dependencies": {
-    "envio": "3.2.0"
+    "envio": "3.3.0-alpha.6"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/cases/erc20-account-balances/envio/pnpm-lock.yaml
+++ b/cases/erc20-account-balances/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.2.0
-        version: 3.2.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.3.0-alpha.6
+        version: 3.3.0-alpha.6(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
@@ -33,6 +33,7 @@ packages:
 
   '@clickhouse/client-common@1.17.0':
     resolution: {integrity: sha512-MiwwgXViFAQA2YZkN4ymF1ynzG0K49KeSX9/iOcmJetWkxqSekDdpyp1GjwATWa9R215uQ+hGzJtJujeQVZZIw==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.17.0':
     resolution: {integrity: sha512-Y3DQoamKZ/Iyosoq7Lj7lqpDkQDK4R/5mI52yJs4ZLPIO+d6/CYDqTbFBIb4No3C/AlXUYE4TKhj/kXDpe6rOA==}
@@ -45,49 +46,6 @@ packages:
   '@elastic/ecs-pino-format@1.4.0':
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-eQyd9kJCIz/4WCTjkjpQg80DA3pdneHP7qhJIVQ2ZG+Jew9o5XDG+uI0Y16AgGzZ6KGmJSJF6wyUaaAjJfbO1Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-l7lRMSoyIiIvKZgQPfgqg7H1xnrQ37A8yUp4S2ys47R8f/wSCSrmMaY1u7n6CxVYCpR9fajwy0/356UgwwhVKw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-kNiC/1fKuXnoSxp8yEsloDw4Ot/mIcNoYYGLl2CipSIpBtSuiBH5nb6eBcxnRZdKOwf5dKZtZ7MVPL9qJocNJw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-XDkvkBG/frS+xiZkJdY4KqOaoAwyxPdi2MysDQgF8NmZdssi32SWch0r4LTqKWLLlCBg9/R55POeXL5UAjg2wQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-DKnKJJSwsYtA7YT0EFGhFB5Eqoo42X0l0vZBv4lDuxngEXiiNjeLemXoKQVDzhcbILD7eyXNa5jWUc+2hpmkEg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-SwIgTAVM9QhCFPyHwL+e1yQ6o3paV6q25klESkXw+r/KW9QPhOOyA6Yr8nfnur3uqMTLJHAKHTLUnkyi/Nh7Aw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -713,36 +671,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.2.0:
-    resolution: {integrity: sha512-UkdZ7MqPh84qcJEygWHEDwWuie3sTpCXGJmQUw3duo2W0NNoq+yFQcoSCe8feDxBJ1Y+TN2UZb7EydIJ2c3a/A==}
+  envio-darwin-arm64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-IBF/wiexpx13qH42DkPzuEN4iQs3O+/NfW2h1WaYn4z21GMqVo7FM8UxDfWlKptBIFE6UajjjGZ/FCfnZ83g6A==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.2.0:
-    resolution: {integrity: sha512-htC7TvdNaLibIEqUfUcwvByQmL3d8cqpCpVlny/EKycef+No8/Kd5wSxH3IRzLXCdQ2w4VhJ6/x/+Mepu59Npw==}
+  envio-darwin-x64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-KaKg1pvzdRoq40BQwgzTsF1d4DaTwu53kqIH5mLiyIHmSNjXX1Ga0GAHo9gIminsMxY4anQlBBYzyOScbXAGzw==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.2.0:
-    resolution: {integrity: sha512-xpEGYefS17B3NgbrHzOcv435kBpsEG2Uy+5lYL5diwpUYqxVJ3bgvoJ4CcABcKBjP/kiuPzrLxtzzf4k0pZGPA==}
+  envio-linux-arm64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-Rn7wBsEvP/76Xepz7LCOypE/lZ89fR091zph/Z1DKSC2NIPF0EV0lDZEh9yQgFlk0owh8PS/pOqvzMGQgHHRrQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.2.0:
-    resolution: {integrity: sha512-QkUGcgHl1w6ry7LId1dlGXsfr5ZzXm8U4Y2rXZgws8S04v1F7gVHR1lzquqt0Bw6a6Bi7dW83LLlTAZswr+glA==}
+  envio-linux-x64-musl@3.3.0-alpha.6:
+    resolution: {integrity: sha512-osaCN27yXhQPfBGyn4WDXksdYunTeFQiMaXly89ZxOJ96hbvAE40QiNNmnvODdMSJItSDBeR0SJnsMc3FWIFdA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.2.0:
-    resolution: {integrity: sha512-QDJyZNwo/pdy2Z4Hdmv+OWV9zEVQ/k+4QzZerogV7ic+rNXs1Z8IWNYwAk1BcD3XaS+0LPedsEhd4NaJeaOV4A==}
+  envio-linux-x64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-iSF7IhvLpu8082pnW+gLHny0dqyHpBIyksghqya8W1pbo/aA5tIH5tWJUumBn/XFV8EW1VK551n89hkrmkb2eg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.2.0:
-    resolution: {integrity: sha512-NhPK2fGHTjwzN9fpPurQyWf++iGz6GQGXqmR4IF7ALrP38lej1OT65j20yq8QlbwWYcVOQ/JDKWOktPuEr0R0g==}
+  envio@3.3.0-alpha.6:
+    resolution: {integrity: sha512-K302y7xBMRnso1m0VEDFFzH14puKiYG4klDVbn9U1HuCP2BMYYTetQpvuMAalTNIJngynWnUAUmy3XrzchRAVQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1079,8 +1037,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  ox@0.12.4:
-    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1403,8 +1361,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.46.2:
-    resolution: {integrity: sha512-w8Qv5Vyo7TfXcH3vgmxRa1NRvzJCDy2aSGSRsJn3503nC/qVbgEQ+n3aj/CkqWXbloudZh97h5o5aQrQSVGy0w==}
+  viem@2.54.0:
+    resolution: {integrity: sha512-DW6KW3m89+3MLozFNPuI9Nhz2hJw375hUo1bpbo3qXipBvjdjF26B/d3U5adVyLGKOfqK4XeA1wPDWQTFQ/ltA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1517,8 +1475,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1529,8 +1487,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1578,33 +1536,6 @@ snapshots:
   '@elastic/ecs-pino-format@1.4.0':
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    optionalDependencies:
-      '@envio-dev/hyperfuel-client-darwin-arm64': 1.2.2
-      '@envio-dev/hyperfuel-client-darwin-x64': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-arm64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
-      '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2069,26 +2000,25 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.2.0:
+  envio-darwin-arm64@3.3.0-alpha.6:
     optional: true
 
-  envio-darwin-x64@3.2.0:
+  envio-darwin-x64@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-arm64@3.2.0:
+  envio-linux-arm64@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-x64-musl@3.2.0:
+  envio-linux-x64-musl@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-x64@3.2.0:
+  envio-linux-x64@3.3.0-alpha.6:
     optional: true
 
-  envio@3.2.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
+  envio@3.3.0-alpha.6(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
-      '@envio-dev/hyperfuel-client': 1.2.2
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -2112,14 +2042,14 @@ snapshots:
       react: 19.2.5
       rescript-schema: 9.5.1
       tsx: 4.21.0
-      viem: 2.46.2(typescript@6.0.3)
+      viem: 2.54.0(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.2.0
-      envio-darwin-x64: 3.2.0
-      envio-linux-arm64: 3.2.0
-      envio-linux-x64: 3.2.0
-      envio-linux-x64-musl: 3.2.0
+      envio-darwin-arm64: 3.3.0-alpha.6
+      envio-darwin-x64: 3.3.0-alpha.6
+      envio-linux-arm64: 3.3.0-alpha.6
+      envio-linux-x64: 3.3.0-alpha.6
+      envio-linux-x64-musl: 3.3.0-alpha.6
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2402,9 +2332,9 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.18.3
+      ws: 8.20.1
 
   joycon@3.1.1: {}
 
@@ -2474,7 +2404,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  ox@0.12.4(typescript@6.0.3):
+  ox@0.14.29(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2836,16 +2766,16 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.46.2(typescript@6.0.3):
+  viem@2.54.0(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@6.0.3)
-      ws: 8.18.3
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.29(typescript@6.0.3)
+      ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2922,9 +2852,9 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
-
   ws@8.19.0: {}
+
+  ws@8.20.1: {}
 
   y18n@5.0.8: {}
 

--- a/cases/erc20-transfer-events/envio/package.json
+++ b/cases/erc20-transfer-events/envio/package.json
@@ -14,7 +14,7 @@
     "vitest": "4.1.6"
   },
   "dependencies": {
-    "envio": "3.2.0"
+    "envio": "3.3.0-alpha.6"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/cases/erc20-transfer-events/envio/pnpm-lock.yaml
+++ b/cases/erc20-transfer-events/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.2.0
-        version: 3.2.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.3.0-alpha.6
+        version: 3.3.0-alpha.6(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
@@ -33,6 +33,7 @@ packages:
 
   '@clickhouse/client-common@1.17.0':
     resolution: {integrity: sha512-MiwwgXViFAQA2YZkN4ymF1ynzG0K49KeSX9/iOcmJetWkxqSekDdpyp1GjwATWa9R215uQ+hGzJtJujeQVZZIw==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.17.0':
     resolution: {integrity: sha512-Y3DQoamKZ/Iyosoq7Lj7lqpDkQDK4R/5mI52yJs4ZLPIO+d6/CYDqTbFBIb4No3C/AlXUYE4TKhj/kXDpe6rOA==}
@@ -45,49 +46,6 @@ packages:
   '@elastic/ecs-pino-format@1.4.0':
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-eQyd9kJCIz/4WCTjkjpQg80DA3pdneHP7qhJIVQ2ZG+Jew9o5XDG+uI0Y16AgGzZ6KGmJSJF6wyUaaAjJfbO1Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-l7lRMSoyIiIvKZgQPfgqg7H1xnrQ37A8yUp4S2ys47R8f/wSCSrmMaY1u7n6CxVYCpR9fajwy0/356UgwwhVKw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-kNiC/1fKuXnoSxp8yEsloDw4Ot/mIcNoYYGLl2CipSIpBtSuiBH5nb6eBcxnRZdKOwf5dKZtZ7MVPL9qJocNJw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-XDkvkBG/frS+xiZkJdY4KqOaoAwyxPdi2MysDQgF8NmZdssi32SWch0r4LTqKWLLlCBg9/R55POeXL5UAjg2wQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-DKnKJJSwsYtA7YT0EFGhFB5Eqoo42X0l0vZBv4lDuxngEXiiNjeLemXoKQVDzhcbILD7eyXNa5jWUc+2hpmkEg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-SwIgTAVM9QhCFPyHwL+e1yQ6o3paV6q25klESkXw+r/KW9QPhOOyA6Yr8nfnur3uqMTLJHAKHTLUnkyi/Nh7Aw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -713,36 +671,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.2.0:
-    resolution: {integrity: sha512-UkdZ7MqPh84qcJEygWHEDwWuie3sTpCXGJmQUw3duo2W0NNoq+yFQcoSCe8feDxBJ1Y+TN2UZb7EydIJ2c3a/A==}
+  envio-darwin-arm64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-IBF/wiexpx13qH42DkPzuEN4iQs3O+/NfW2h1WaYn4z21GMqVo7FM8UxDfWlKptBIFE6UajjjGZ/FCfnZ83g6A==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.2.0:
-    resolution: {integrity: sha512-htC7TvdNaLibIEqUfUcwvByQmL3d8cqpCpVlny/EKycef+No8/Kd5wSxH3IRzLXCdQ2w4VhJ6/x/+Mepu59Npw==}
+  envio-darwin-x64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-KaKg1pvzdRoq40BQwgzTsF1d4DaTwu53kqIH5mLiyIHmSNjXX1Ga0GAHo9gIminsMxY4anQlBBYzyOScbXAGzw==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.2.0:
-    resolution: {integrity: sha512-xpEGYefS17B3NgbrHzOcv435kBpsEG2Uy+5lYL5diwpUYqxVJ3bgvoJ4CcABcKBjP/kiuPzrLxtzzf4k0pZGPA==}
+  envio-linux-arm64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-Rn7wBsEvP/76Xepz7LCOypE/lZ89fR091zph/Z1DKSC2NIPF0EV0lDZEh9yQgFlk0owh8PS/pOqvzMGQgHHRrQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.2.0:
-    resolution: {integrity: sha512-QkUGcgHl1w6ry7LId1dlGXsfr5ZzXm8U4Y2rXZgws8S04v1F7gVHR1lzquqt0Bw6a6Bi7dW83LLlTAZswr+glA==}
+  envio-linux-x64-musl@3.3.0-alpha.6:
+    resolution: {integrity: sha512-osaCN27yXhQPfBGyn4WDXksdYunTeFQiMaXly89ZxOJ96hbvAE40QiNNmnvODdMSJItSDBeR0SJnsMc3FWIFdA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.2.0:
-    resolution: {integrity: sha512-QDJyZNwo/pdy2Z4Hdmv+OWV9zEVQ/k+4QzZerogV7ic+rNXs1Z8IWNYwAk1BcD3XaS+0LPedsEhd4NaJeaOV4A==}
+  envio-linux-x64@3.3.0-alpha.6:
+    resolution: {integrity: sha512-iSF7IhvLpu8082pnW+gLHny0dqyHpBIyksghqya8W1pbo/aA5tIH5tWJUumBn/XFV8EW1VK551n89hkrmkb2eg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.2.0:
-    resolution: {integrity: sha512-NhPK2fGHTjwzN9fpPurQyWf++iGz6GQGXqmR4IF7ALrP38lej1OT65j20yq8QlbwWYcVOQ/JDKWOktPuEr0R0g==}
+  envio@3.3.0-alpha.6:
+    resolution: {integrity: sha512-K302y7xBMRnso1m0VEDFFzH14puKiYG4klDVbn9U1HuCP2BMYYTetQpvuMAalTNIJngynWnUAUmy3XrzchRAVQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1079,8 +1037,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  ox@0.12.4:
-    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1403,8 +1361,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.46.2:
-    resolution: {integrity: sha512-w8Qv5Vyo7TfXcH3vgmxRa1NRvzJCDy2aSGSRsJn3503nC/qVbgEQ+n3aj/CkqWXbloudZh97h5o5aQrQSVGy0w==}
+  viem@2.54.0:
+    resolution: {integrity: sha512-DW6KW3m89+3MLozFNPuI9Nhz2hJw375hUo1bpbo3qXipBvjdjF26B/d3U5adVyLGKOfqK4XeA1wPDWQTFQ/ltA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1517,8 +1475,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1529,8 +1487,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1578,33 +1536,6 @@ snapshots:
   '@elastic/ecs-pino-format@1.4.0':
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    optionalDependencies:
-      '@envio-dev/hyperfuel-client-darwin-arm64': 1.2.2
-      '@envio-dev/hyperfuel-client-darwin-x64': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-arm64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
-      '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2069,26 +2000,25 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.2.0:
+  envio-darwin-arm64@3.3.0-alpha.6:
     optional: true
 
-  envio-darwin-x64@3.2.0:
+  envio-darwin-x64@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-arm64@3.2.0:
+  envio-linux-arm64@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-x64-musl@3.2.0:
+  envio-linux-x64-musl@3.3.0-alpha.6:
     optional: true
 
-  envio-linux-x64@3.2.0:
+  envio-linux-x64@3.3.0-alpha.6:
     optional: true
 
-  envio@3.2.0(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
+  envio@3.3.0-alpha.6(react-dom@19.2.4(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
-      '@envio-dev/hyperfuel-client': 1.2.2
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -2112,14 +2042,14 @@ snapshots:
       react: 19.2.5
       rescript-schema: 9.5.1
       tsx: 4.21.0
-      viem: 2.46.2(typescript@6.0.3)
+      viem: 2.54.0(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.2.0
-      envio-darwin-x64: 3.2.0
-      envio-linux-arm64: 3.2.0
-      envio-linux-x64: 3.2.0
-      envio-linux-x64-musl: 3.2.0
+      envio-darwin-arm64: 3.3.0-alpha.6
+      envio-darwin-x64: 3.3.0-alpha.6
+      envio-linux-arm64: 3.3.0-alpha.6
+      envio-linux-x64: 3.3.0-alpha.6
+      envio-linux-x64-musl: 3.3.0-alpha.6
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2402,9 +2332,9 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.18.3
+      ws: 8.20.1
 
   joycon@3.1.1: {}
 
@@ -2474,7 +2404,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  ox@0.12.4(typescript@6.0.3):
+  ox@0.14.29(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2836,16 +2766,16 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.46.2(typescript@6.0.3):
+  viem@2.54.0(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@6.0.3)
-      ws: 8.18.3
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.29(typescript@6.0.3)
+      ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2922,9 +2852,9 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
-
   ws@8.19.0: {}
+
+  ws@8.20.1: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
This pull request upgrades the `envio` package dependency from version 3.2.0 to 3.3.0-alpha.6 across multiple test case projects.

## Key Changes
- Updated `envio` dependency in `cases/erc20-account-balances/envio/package.json` from 3.2.0 to 3.3.0-alpha.6
- Updated `envio` dependency in `cases/erc20-transfer-events/envio/package.json` from 3.2.0 to 3.3.0-alpha.6

## Notes
This upgrade targets an alpha version of envio, which may include experimental features or breaking changes. The lockfiles have been updated to reflect the new dependency resolution.

https://claude.ai/code/session_01Xw7LMoZY1ik8zWfRb9tWBE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying tooling dependency to a newer pre-release version in two example projects.
  * No user-facing behavior, features, or settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->